### PR TITLE
Add toast for adhkar checkboxes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "i18n-ally.localesPaths": ["i18n", "messages"]
+}

--- a/components/features/dashboard/daily-tracking-table.tsx
+++ b/components/features/dashboard/daily-tracking-table.tsx
@@ -80,6 +80,21 @@ export default function DailyTrackingTable() {
       updateQuranCount(day, value);
     } else {
       updateDhikr(day, field, value);
+
+      if (value === '1') {
+        const activityLabel =
+          field === 'dhikrMorning'
+            ? t('table.dhikr_morning')
+            : t('table.dhikr_evening');
+
+        toast({
+          title: t('activity_updated'),
+          description: t('activity_desc', {
+            activity: activityLabel,
+            day,
+          }),
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Show a toast when Morning/Evening Adhkar checkboxes are checked in the daily tracking table.
- Reuse existing Dashboard activity toast copy and localization.

## Test Plan
- Open the dashboard days table.
- Check Morning Adhkar for any day and verify a toast appears with the correct day and label.
- Check Evening Adhkar for any day and verify a toast appears with the correct day and label.
- Uncheck both and confirm no toast is shown on uncheck.


Made with [Cursor](https://cursor.com)