### PR TITLE
Toast alerts for achievements, goals, and daily completion

### DIFF
--- a/components/features/achievements/achievement-badges.tsx
+++ b/components/features/achievements/achievement-badges.tsx
@@ -3,20 +3,14 @@
 import type React from 'react';
 import { useState, useEffect, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import {
-  BookOpen,
-  Clock,
-  Heart,
-  AlignJustify,
-  Star,
-  Trophy,
-} from 'lucide-react';
+import { BookOpen, Clock, Heart, AlignJustify, Star, Trophy } from 'lucide-react';
 import { useRamadanStore } from '@/lib/store';
 import type { DailyActivity } from '@/lib/store';
 import { motion } from 'framer-motion';
 import { Progress } from '@/components/ui/progress';
 import { formatNumber } from '@/lib/arabic-numerals';
 import { useTranslations, useLocale } from 'next-intl';
+import { useToast } from '@/components/ui/use-toast';
 
 interface Achievement {
   id: string;
@@ -35,6 +29,20 @@ export default function AchievementBadges() {
   const t = useTranslations('Achievements');
   const locale = useLocale();
   const { activities, stats } = useRamadanStore();
+  const { toast } = useToast();
+  const [notifiedIds, setNotifiedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('rt_notified_achievements');
+      if (stored) {
+        setNotifiedIds(JSON.parse(stored));
+      }
+    } catch {
+      
+    }
+  }, []);
 
   const achievements = useMemo(() => {
     const quranPages = activities.reduce(
@@ -52,6 +60,21 @@ export default function AchievementBadges() {
     const goodDeedsDays = activities.filter(
       (day: DailyActivity) =>
         day.charity || day.familyVisit || day.happiness || day.feeding,
+    ).length;
+    const fullyTrackedDays = activities.filter(
+      (day: DailyActivity) =>
+        day.fasting &&
+        day.qiyam &&
+        day.duha &&
+        day.rawatib &&
+        day.charity &&
+        day.familyVisit &&
+        day.happiness &&
+        day.feeding &&
+        day.dhikrMorning !== '0' &&
+        day.dhikrMorning !== '' &&
+        day.dhikrEvening !== '0' &&
+        day.dhikrEvening !== '',
     ).length;
 
     return [
@@ -125,8 +148,68 @@ export default function AchievementBadges() {
         progress: Math.min(stats.overall, 80),
         target: 80,
       },
+      {
+        id: 'first-week-tracking',
+        title: t('badges.first_week.title'),
+        description: t('badges.first_week.description'),
+        icon: <Clock className='h-6 w-6' />,
+        color: 'teal-500',
+        unlocked: fullyTrackedDays >= 7,
+        progress: Math.min(fullyTrackedDays, 7),
+        target: 7,
+      },
+      {
+        id: 'ten-day-streak',
+        title: t('badges.ten_day_streak.title'),
+        description: t('badges.ten_day_streak.description'),
+        icon: <Star className='h-6 w-6' />,
+        color: 'cyan-500',
+        unlocked: fullyTrackedDays >= 10,
+        progress: Math.min(fullyTrackedDays, 10),
+        target: 10,
+      },
+      {
+        id: 'quran-khatm',
+        title: t('badges.quran_khatm.title'),
+        description: t('badges.quran_khatm.description'),
+        icon: <BookOpen className='h-6 w-6' />,
+        color: 'emerald-600',
+        unlocked: stats.quran >= 100,
+        progress: Math.min(stats.quran, 100),
+        target: 100,
+      },
     ];
   }, [activities, stats, t]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const newlyUnlocked = achievements.filter(
+      (a) => a.unlocked && !notifiedIds.includes(a.id),
+    );
+
+    if (!newlyUnlocked.length) return;
+
+    newlyUnlocked.forEach((achievement) => {
+      toast({
+        title: t('toast_new_badge_title'),
+        description: t('toast_new_badge_desc', { badge: achievement.title }),
+      });
+    });
+
+    const updatedIds = [
+      ...new Set([...notifiedIds, ...newlyUnlocked.map((a) => a.id)]),
+    ];
+    setNotifiedIds(updatedIds);
+    try {
+      window.localStorage.setItem(
+        'rt_notified_achievements',
+        JSON.stringify(updatedIds),
+      );
+    } catch {
+      
+    }
+  }, [achievements, notifiedIds, t, toast]);
 
   return (
     <div className={locale === 'ar' ? 'rtl' : 'ltr'}>

--- a/components/features/dashboard/daily-tracking-table.tsx
+++ b/components/features/dashboard/daily-tracking-table.tsx
@@ -37,13 +37,45 @@ export default function DailyTrackingTable() {
     currentPage * itemsPerPage,
   );
 
+  const isDayComplete = (activity: DailyActivity) =>
+    activity.fasting &&
+    activity.qiyam &&
+    activity.duha &&
+    activity.rawatib &&
+    activity.charity &&
+    activity.familyVisit &&
+    activity.happiness &&
+    activity.feeding &&
+    activity.dhikrMorning !== '0' &&
+    activity.dhikrMorning !== '' &&
+    activity.dhikrEvening !== '0' &&
+    activity.dhikrEvening !== '';
+
+  const maybeShowDailyCompleteToast = (day: number) => {
+    if (typeof window === 'undefined') return;
+    const key = `rt_daily_complete_${day}`;
+    if (window.localStorage.getItem(key) === '1') return;
+
+    const activity = activities.find((a: DailyActivity) => a.day === day);
+    if (!activity || !isDayComplete(activity)) return;
+
+    toast({
+      title: t('daily_complete_title'),
+      description: t('daily_complete_desc', { day }),
+    });
+    try {
+      window.localStorage.setItem(key, '1');
+    } catch {
+      
+    }
+  };
+
   const handleCheckboxChange = (day: number, field: keyof DailyActivity) => {
     const activity = activities.find((a: DailyActivity) => a.day === day);
     if (activity) {
       const newValue = !activity[field];
       updateActivity(day, field, newValue);
 
-      
       if (newValue) {
         toast({
           title: t('activity_updated'),
@@ -52,6 +84,7 @@ export default function DailyTrackingTable() {
             day,
           }),
         });
+        maybeShowDailyCompleteToast(day);
       }
     }
   };
@@ -94,6 +127,7 @@ export default function DailyTrackingTable() {
             day,
           }),
         });
+        maybeShowDailyCompleteToast(day);
       }
     }
   };

--- a/components/features/journey/ramadan-goals.tsx
+++ b/components/features/journey/ramadan-goals.tsx
@@ -20,6 +20,7 @@ import { useRamadanStore } from '@/lib/store';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Badge } from '@/components/ui/badge';
 import type { RamadanGoal } from '@/lib/store/types';
+import { useToast } from '@/components/ui/use-toast';
 
 const categoryIcons = {
   quran: <Book className='h-4 w-4' />,
@@ -34,12 +35,25 @@ export function RamadanGoals() {
   const { goals, addGoal, toggleGoal, removeGoal } = useRamadanStore();
   const [newGoalText, setNewGoalText] = useState('');
   const [category, setCategory] = useState<RamadanGoal['category']>('personal');
+  const { toast } = useToast();
 
   const handleAddGoal = (e: React.FormEvent) => {
     e.preventDefault();
     if (newGoalText.trim()) {
       addGoal(newGoalText.trim(), category);
       setNewGoalText('');
+    }
+  };
+
+  const handleToggleGoal = (goal: RamadanGoal) => {
+    const willComplete = !goal.completed;
+    toggleGoal(goal.id);
+
+    if (willComplete) {
+      toast({
+        title: t('toast_goal_completed_title'),
+        description: t('toast_goal_completed_desc', { goal: goal.text }),
+      });
     }
   };
 
@@ -105,7 +119,7 @@ export function RamadanGoals() {
               >
                 <div className='flex items-center gap-3'>
                   <button
-                    onClick={() => toggleGoal(goal.id)}
+                    onClick={() => handleToggleGoal(goal)}
                     className={`transition-colors ${
                       goal.completed
                         ? 'text-green-500'

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -36,7 +36,9 @@
         "charity": "الصدقة",
         "personal": "شخصي",
         "other": "أخرى"
-      }
+      },
+      "toast_goal_completed_title": "تم إنجاز الهدف",
+      "toast_goal_completed_desc": "✅ تم تحقيق الهدف: {goal}"
     },
     "Journal": {
       "title": "تأملات اليوم {day}",
@@ -72,6 +74,8 @@
     "reset_desc": "تم إعادة تعيين جميع الأنشطة ليوم {day} من رمضان",
     "activity_updated": "تم تحديث النشاط",
     "activity_desc": "تم تسجيل {activity} ليوم {day} من رمضان",
+    "daily_complete_title": "ما شاء الله! يوم مكتمل",
+    "daily_complete_desc": "لقد أكملت جميع الأنشطة ليوم {day} من رمضان",
     "next": "التالي",
     "previous": "السابق",
     "page_info": "صفحة {current} من {total}",
@@ -215,8 +219,22 @@
       "ramadan_champion": {
         "title": "بطل رمضان",
         "description": "إكمال شهر رمضان بنسبة إنجاز 80%"
+      },
+      "first_week": {
+        "title": "أول أسبوع من الانضباط",
+        "description": "إكمال جميع الأنشطة لمدة 7 أيام"
+      },
+      "ten_day_streak": {
+        "title": "سلسلة 10 أيام",
+        "description": "إكمال جميع الأنشطة لمدة 10 أيام"
+      },
+      "quran_khatm": {
+        "title": "ختم القرآن",
+        "description": "إكمال ختم كامل للقرآن الكريم"
       }
-    }
+    },
+    "toast_new_badge_title": "🏆 تم فتح إنجاز جديد!",
+    "toast_new_badge_desc": "لقد حصلت على: {badge}"
   },
   "Quran": {
     "title": "متابع القرآن",

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,7 +36,9 @@
         "charity": "Charity",
         "personal": "Personal",
         "other": "Other"
-      }
+      },
+      "toast_goal_completed_title": "Goal achieved",
+      "toast_goal_completed_desc": "✅ Goal achieved: {goal}"
     },
     "Journal": {
       "title": "Day {day} Reflections",
@@ -72,6 +74,8 @@
     "reset_desc": "All activities for day {day} of Ramadan have been reset",
     "activity_updated": "Activity Updated",
     "activity_desc": "{activity} for day {day} of Ramadan has been recorded",
+    "daily_complete_title": "MashaAllah! Day completed",
+    "daily_complete_desc": "You completed all activities for day {day} of Ramadan",
     "next": "Next",
     "previous": "Previous",
     "page_info": "Page {current} of {total}",
@@ -218,8 +222,22 @@
       "ramadan_champion": {
         "title": "Ramadan Champion",
         "description": "Complete Ramadan with 80% progress"
+      },
+      "first_week": {
+        "title": "First Week Consistency",
+        "description": "Complete all activities for 7 days"
+      },
+      "ten_day_streak": {
+        "title": "10-Day Streak",
+        "description": "Complete all activities for 10 days"
+      },
+      "quran_khatm": {
+        "title": "Quran Completion",
+        "description": "Complete a full recitation (khatm) of the Quran"
       }
-    }
+    },
+    "toast_new_badge_title": "🏆 New achievement unlocked!",
+    "toast_new_badge_desc": "You earned: {badge}"
   },
   "Quran": {
     "title": "Quran Tracker",


### PR DESCRIPTION
## Summary
- Add localized celebratory toasts when new achievement badges are unlocked, including new milestone badges (first week, 10-day streak, Quran khatm).
- Show a motivational toast when a day in the dashboard is fully completed, with localStorage-based deduping per day.
- Trigger a celebration toast when a Ramadan goal is marked completed.

## Details
- Achievement unlock toasts are de-duplicated using localStorage key `rt_notified_achievements`.
- Daily completion toasts are de-duplicated per day using `rt_daily_complete_{day}`.

## Linked Issue
Closes #25


Made with [Cursor](https://cursor.com)